### PR TITLE
feat: add Tavily Extract as parallel scraping option alongside Firecrawl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ GOOGLE_API_KEY=your-gemini-api-key
 # ANTHROPIC_API_KEY=your-claude-api-key
 # OPENAI_API_KEY=your-openai-api-key
 
+# Optional: Tavily API (enables web search + page content extraction)
+# TAVILY_API_KEY=tvly-your-tavily-api-key
+
 # Optional: Fallback Gemini API keys for rate limit resilience
 # GOOGLE_API_KEY_FALLBACK=your-fallback-key
 # GOOGLE_API_KEY_FALLBACK_2=your-second-fallback-key

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -20,6 +20,7 @@ python-docx>=1.0.0          # Word document generation
 requests>=2.31.0            # For CrossRef API, GPTZero API, web scraping
 beautifulsoup4>=4.12.0      # HTML parsing for title/metadata scraping
 lxml>=4.9.0                 # Fast XML/HTML parser for BeautifulSoup
+tavily-python>=0.5.0        # Tavily API client (web search + extract)
 
 # === Utilities ===
 python-dotenv>=1.0.0        # Load .env files

--- a/engine/utils/fallback_services.py
+++ b/engine/utils/fallback_services.py
@@ -5,12 +5,14 @@ Fallback Services for Web Search and Page Scraping
 Tools:
 - Serper.dev: Web search via Google SERP API (preferred)
 - DataForSEO: Web search via SERP API (2000 RPM) (legacy fallback)
-- Firecrawl: Page scraping with JavaScript rendering (preferred)
+- Tavily Extract: Page content extraction via Tavily API (preferred when TAVILY_API_KEY set)
+- Firecrawl: Page scraping with JavaScript rendering (fallback)
 - OpenPull: Page scraping with JavaScript rendering (crawl4ai + Playwright) (legacy)
 - Simple fallback: Basic requests-based scraping for non-JS pages
 
 Usage:
     from fallback_services import search_web_serper, scrape_page_with_firecrawl
+    from fallback_services import scrape_page_with_tavily
     # Legacy:
     from fallback_services import search_web_dataforseo, scrape_page_with_openpull
 """
@@ -100,14 +102,46 @@ def search_web_serper(
 
 
 # ==============================================================================
-# Firecrawl Page Scraping (Preferred)
+# Tavily Extract Page Scraping (Preferred when TAVILY_API_KEY is set)
+# ==============================================================================
+
+def scrape_page_with_tavily(url: str) -> Dict[str, Any]:
+    """
+    Extract webpage content using Tavily Extract API.
+
+    Args:
+        url: The URL to extract content from
+
+    Returns:
+        Dict with 'success', 'content', and 'error' if failed
+
+    Environment Variables Required:
+        TAVILY_API_KEY: Tavily API key
+    """
+    try:
+        from utils.tavily_extract_client import TavilyExtractClient
+
+        client = TavilyExtractClient()
+        if not client.enabled:
+            return {'success': False, 'error': 'Tavily Extract not configured', 'content': ''}
+        return client.scrape_url(url)
+
+    except ImportError:
+        logger.warning("tavily-python not installed, skipping Tavily Extract")
+        return {'success': False, 'error': 'tavily-python not installed', 'content': ''}
+    except Exception as e:
+        logger.warning(f"Tavily Extract failed: {e}")
+        return {'success': False, 'error': str(e), 'content': ''}
+
+
+# ==============================================================================
+# Firecrawl Page Scraping (Fallback after Tavily Extract)
 # ==============================================================================
 
 def scrape_page_with_firecrawl(url: str) -> Dict[str, Any]:
     """
-    Scrape a webpage using Firecrawl API.
-
-    Preferred over OpenPull/crawl4ai for reliability and JS rendering.
+    Scrape a webpage, trying Tavily Extract first (if configured),
+    then Firecrawl, then simple scraper as final fallback.
 
     Args:
         url: The URL to scrape
@@ -115,9 +149,18 @@ def scrape_page_with_firecrawl(url: str) -> Dict[str, Any]:
     Returns:
         Dict with 'success', 'content', and 'error' if failed
 
-    Environment Variables Required:
-        FIRECRAWL_API_KEY: Firecrawl API key
+    Environment Variables:
+        TAVILY_API_KEY: Tavily API key (enables Tavily Extract as primary)
+        FIRECRAWL_API_KEY: Firecrawl API key (secondary fallback)
     """
+    # Try Tavily Extract first when TAVILY_API_KEY is set
+    if os.environ.get('TAVILY_API_KEY'):
+        result = scrape_page_with_tavily(url)
+        if result.get('success'):
+            return result
+        logger.info(f"Tavily Extract failed for {url}, falling back to Firecrawl")
+
+    # Firecrawl as secondary
     try:
         from utils.firecrawl_client import FirecrawlClient
 

--- a/engine/utils/tavily_extract_client.py
+++ b/engine/utils/tavily_extract_client.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tavily Extract API client for web page content extraction
+ABOUTME: Parallel option alongside Firecrawl for page scraping
+"""
+
+import os
+import logging
+from typing import Optional, Dict, Any, List
+
+try:
+    from tavily import TavilyClient
+except ImportError:
+    TavilyClient = None
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    load_dotenv = None
+
+logger = logging.getLogger(__name__)
+
+
+class TavilyExtractClient:
+    """
+    Tavily Extract API client for web page content extraction.
+
+    Uses Tavily's extract() endpoint to fetch clean content from URLs.
+    Returns the same {success, content, url, metadata} dict that
+    FirecrawlClient.scrape_url() returns for drop-in compatibility.
+
+    Requirements:
+    - tavily-python
+    - TAVILY_API_KEY environment variable
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initialize Tavily Extract client.
+
+        Args:
+            api_key: Tavily API key (defaults to TAVILY_API_KEY env var)
+        """
+        if load_dotenv is not None:
+            load_dotenv()
+
+        self.api_key = api_key or os.getenv('TAVILY_API_KEY')
+
+        if not TavilyClient:
+            raise ImportError("tavily-python not installed. Run: pip install tavily-python")
+
+        if self.api_key:
+            self._client = TavilyClient(api_key=self.api_key)
+        else:
+            self._client = None
+
+    @property
+    def enabled(self) -> bool:
+        """Check if Tavily Extract is configured and available."""
+        return bool(self.api_key and self._client)
+
+    def scrape_url(self, url: str) -> Dict[str, Any]:
+        """
+        Extract content from a webpage using Tavily Extract.
+
+        Args:
+            url: The URL to extract content from
+
+        Returns:
+            Dict with:
+                - success: bool
+                - content: str (extracted text content)
+                - url: str
+                - metadata: dict
+                - error: str (if failed)
+        """
+        if not self.enabled:
+            return {
+                'success': False,
+                'error': 'Tavily Extract not configured (TAVILY_API_KEY missing)',
+                'content': '',
+                'url': url,
+                'metadata': {},
+            }
+
+        try:
+            response = self._client.extract(urls=[url])
+
+            results = response.get('results', [])
+            if results:
+                result = results[0]
+                raw_content = result.get('raw_content', '')
+
+                if not raw_content or not raw_content.strip():
+                    return {
+                        'success': False,
+                        'error': f'Tavily Extract returned empty content for {url}',
+                        'content': '',
+                        'url': url,
+                        'metadata': {},
+                    }
+
+                # Truncate to reasonable length (matching Firecrawl convention)
+                if len(raw_content) > 15000:
+                    raw_content = raw_content[:15000] + "\n\n... [content truncated]"
+
+                logger.info(f"[TavilyExtract] Extracted {len(raw_content)} chars from: {url[:50]}...")
+
+                return {
+                    'success': True,
+                    'content': raw_content,
+                    'url': result.get('url', url),
+                    'metadata': {},
+                }
+
+            # Check for failed results
+            failed = response.get('failed_results', [])
+            if failed:
+                error_msg = failed[0].get('error', 'Unknown extraction error')
+                logger.warning(f"[TavilyExtract] Failed for {url}: {error_msg}")
+                return {
+                    'success': False,
+                    'error': f'Tavily Extract failed: {error_msg}',
+                    'content': '',
+                    'url': url,
+                    'metadata': {},
+                }
+
+            return {
+                'success': False,
+                'error': f'Tavily Extract returned no results for {url}',
+                'content': '',
+                'url': url,
+                'metadata': {},
+            }
+
+        except Exception as e:
+            logger.warning(f"[TavilyExtract] Error for {url}: {e}")
+            return {
+                'success': False,
+                'error': str(e),
+                'content': '',
+                'url': url,
+                'metadata': {},
+            }


### PR DESCRIPTION
## Summary

Adds Tavily Extract as a configurable page content extraction option alongside the existing Firecrawl provider. When `TAVILY_API_KEY` is set, Tavily Extract is tried first for page scraping, with Firecrawl as secondary fallback and the simple requests-based scraper as tertiary fallback.

**Why:** Tavily Extract provides an alternative content extraction API that can improve reliability and reduce dependency on a single scraping provider.

## Changes

- **`engine/utils/tavily_extract_client.py`** (new): `TavilyExtractClient` wrapping `TavilyClient.extract()`, returning the same `{success, content, url, metadata}` dict as `FirecrawlClient.scrape_url()`
- **`engine/utils/fallback_services.py`**: Added `scrape_page_with_tavily()` function; updated `scrape_page_with_firecrawl()` to attempt Tavily Extract first when `TAVILY_API_KEY` is set
- **`engine/requirements.txt`**: Added `tavily-python>=0.5.0`
- **`.env.example`**: Documented `TAVILY_API_KEY` (also enables Extract)

## Dependency changes

- Added `tavily-python>=0.5.0` to `engine/requirements.txt`

## Environment variable changes

- `TAVILY_API_KEY`: When set, enables Tavily Extract as the primary page scraping method (also used for web search if that migration unit is applied)

## Notes for reviewers

- Firecrawl and `FIRECRAWL_API_KEY` remain fully functional and unchanged
- Tavily Extract only activates when `TAVILY_API_KEY` is present in the environment
- The fallback chain is: Tavily Extract → Firecrawl → simple requests scraper
- `TavilyExtractClient` gracefully handles missing `tavily-python` package via ImportError


### Automated Review

- Passed after 1 attempt(s)
- Final review: The implementation correctly adds Tavily Extract as a primary page-scraping option with Firecrawl as fallback. The new TavilyExtractClient is well-structured, returns a drop-in compatible response dict, handles all error cases (empty results, failed_results, exceptions), and the fallback chain in scrape_page_with_firecrawl is implemented cleanly. All four planned files are changed, the tavily-python dependency is pinned correctly, and TAVILY_API_KEY is documented in .env.example. Note: the migration plan stated TAVILY_API_KEY would already be in .env.example from the prerequisite unit, but neither that unit's PR description nor the git diff support this — this unit adds it correctly regardless. Only minor issues found; no critical or major blockers.
