### PR TITLE
feat: add benchmark topic dataset for evaluation suite

### DIFF
--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -93,7 +93,60 @@ python scripts/eval_regression.py --baseline reports/baseline.json
 python scripts/eval_cross_model.py --providers gemini,openai,anthropic
 ```
 
+## Benchmark Topic Dataset
+
+To support reproducible evaluation, OpenDraft includes a benchmark dataset containing 20 research topics across multiple academic domains.
+
+### Covered Domains
+
+- Computer Science
+- Medicine
+- Economics
+- Social Science
+- Physics
+- Biology
+
+### Dataset Structure
+
+Each topic includes:
+
+- Topic name
+- Academic domain
+- Canonical research papers associated with the topic
+
+The canonical papers act as reference sources for evaluating:
+
+- Citation accuracy
+- Source coverage
+- Retrieval quality
+- Cross-model consistency
+- Regression testing
+
+### Dataset Location
+
+```text
+data/eval_topics.json
+```
+
+### Evaluation Criteria
+
+The benchmark dataset is intended to provide a consistent evaluation baseline across different OpenDraft evaluation suites.
+
+Evaluations using this dataset may measure:
+
+| Metric | Description |
+|----------|-------------|
+| Citation Verification Rate | Percentage of citations that can be successfully verified against trusted databases |
+| Source Coverage | Whether canonical papers are retrieved during the research phase |
+| Retrieval Recall | Number of expected sources discovered within the retrieved set |
+| Cross-Model Consistency | Differences in retrieval and citation quality across LLM providers |
+| Regression Stability | Changes in evaluation metrics across releases and code changes |
+
+The dataset should remain stable over time so benchmark results can be compared across versions of OpenDraft.
+
+
 ## Contributing to Evals
+```md
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup. Evaluation PRs are welcome:
 

--- a/data/eval_topics.json
+++ b/data/eval_topics.json
@@ -1,0 +1,107 @@
+[
+{
+"topic": "Transformer Architecture",
+"domain": "Computer Science",
+"canonical_papers": ["Attention Is All You Need (2017)"]
+},
+{
+"topic": "Convolutional Neural Networks",
+"domain": "Computer Science",
+"canonical_papers": ["ImageNet Classification with Deep Convolutional Neural Networks (2012)"]
+},
+{
+"topic": "Reinforcement Learning",
+"domain": "Computer Science",
+"canonical_papers": ["Human-level control through deep reinforcement learning (2015)"]
+},
+{
+"topic": "Graph Neural Networks",
+"domain": "Computer Science",
+"canonical_papers": ["The Graph Neural Network Model (2009)"]
+},
+
+{
+"topic": "mRNA Vaccines",
+"domain": "Medicine",
+"canonical_papers": ["mRNA vaccines — a new era in vaccinology (2018)"]
+},
+{
+"topic": "Cancer Immunotherapy",
+"domain": "Medicine",
+"canonical_papers": ["The blockade of immune checkpoints in cancer immunotherapy (2012)"]
+},
+{
+"topic": "COVID-19 Epidemiology",
+"domain": "Medicine",
+"canonical_papers": ["Clinical features of patients infected with 2019 novel coronavirus in Wuhan, China (2020)"]
+},
+{
+"topic": "Precision Medicine",
+"domain": "Medicine",
+"canonical_papers": ["Precision Medicine Initiative Cohort Program (2015)"]
+},
+
+{
+"topic": "Behavioral Economics",
+"domain": "Economics",
+"canonical_papers": ["Prospect Theory: An Analysis of Decision under Risk (1979)"]
+},
+{
+"topic": "Economic Growth",
+"domain": "Economics",
+"canonical_papers": ["A Contribution to the Theory of Economic Growth (1956)"]
+},
+{
+"topic": "Market Efficiency",
+"domain": "Economics",
+"canonical_papers": ["Efficient Capital Markets: A Review of Theory and Empirical Work (1970)"]
+},
+
+{
+"topic": "Social Capital",
+"domain": "Social Science",
+"canonical_papers": ["Bowling Alone: America's Declining Social Capital (1995)"]
+},
+{
+"topic": "Digital Inequality",
+"domain": "Social Science",
+"canonical_papers": ["The Deepening Divide: Inequality in the Information Society (2001)"]
+},
+{
+"topic": "Collective Action",
+"domain": "Social Science",
+"canonical_papers": ["The Logic of Collective Action (1965)"]
+},
+
+{
+"topic": "Quantum Entanglement",
+"domain": "Physics",
+"canonical_papers": ["Can Quantum-Mechanical Description of Physical Reality Be Considered Complete? (1935)"]
+},
+{
+"topic": "Higgs Boson",
+"domain": "Physics",
+"canonical_papers": ["Broken Symmetries and the Masses of Gauge Bosons (1964)"]
+},
+{
+"topic": "Gravitational Waves",
+"domain": "Physics",
+"canonical_papers": ["Observation of Gravitational Waves from a Binary Black Hole Merger (2016)"]
+},
+
+{
+"topic": "CRISPR Gene Editing",
+"domain": "Biology",
+"canonical_papers": ["A Programmable Dual-RNA-Guided DNA Endonuclease in Adaptive Bacterial Immunity (2012)"]
+},
+{
+"topic": "Evolution by Natural Selection",
+"domain": "Biology",
+"canonical_papers": ["On the Origin of Species (1859)"]
+},
+{
+"topic": "Human Genome Project",
+"domain": "Biology",
+"canonical_papers": ["Initial sequencing and analysis of the human genome (2001)"]
+}
+]


### PR DESCRIPTION
## Summary

This PR adds a reproducible benchmark topic dataset for OpenDraft evaluations and documents how the dataset can be used across evaluation suites.

## Changes

* Added `data/eval_topics.json` containing 20 benchmark research topics.
* Covered multiple domains:

  * Computer Science
  * Medicine
  * Economics
  * Social Science
  * Physics
  * Biology
* Included canonical papers for each topic to support source coverage and citation evaluation.
* Added a new **Benchmark Topic Dataset** section to `EVALUATION.md`.
* Documented dataset purpose, structure, location, and evaluation criteria.

## Why

The evaluation plan references benchmark topics and canonical papers for measuring citation accuracy, source coverage, regression stability, and cross-model consistency. This dataset provides a consistent baseline that can be reused across future evaluation runs and benchmarking workflows.
