### PR TITLE
Add citation evaluation regression script

### DIFF
--- a/EVALUATION.md
+++ b/EVALUATION.md
@@ -86,8 +86,11 @@ OpenDraft is an open-source research drafting engine with 19 specialized agents.
 # Run full evaluation suite
 python scripts/eval_citation_accuracy.py --topics data/eval_topics.json --output reports/
 
-# Run regression test against golden topics
-python scripts/eval_regression.py --baseline reports/baseline.json
+# Run regression test against existing golden-topic drafts
+python scripts/eval_regression.py --drafts-dir reports/eval_drafts --baseline reports/baseline.json
+
+# Or generate fresh drafts before measuring (requires configured API keys)
+python scripts/eval_regression.py --generate --baseline reports/baseline.json
 
 # Generate comparison report across models
 python scripts/eval_cross_model.py --providers gemini,openai,anthropic

--- a/data/eval_topics.json
+++ b/data/eval_topics.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "rag_reliability",
+    "topic": "Reliability evaluation methods for retrieval-augmented generation systems",
+    "level": "research_paper"
+  },
+  {
+    "id": "ai_citation_integrity",
+    "topic": "Citation integrity and hallucination detection in AI-assisted academic writing",
+    "level": "research_paper"
+  },
+  {
+    "id": "clinical_llm_safety",
+    "topic": "Safety evaluation frameworks for large language models in clinical decision support",
+    "level": "research_paper"
+  },
+  {
+    "id": "education_ai_feedback",
+    "topic": "Effects of generative AI feedback on higher education writing outcomes",
+    "level": "research_paper"
+  },
+  {
+    "id": "agentic_research_workflows",
+    "topic": "Multi-agent workflows for source-grounded literature review automation",
+    "level": "research_paper"
+  }
+]

--- a/scripts/eval_regression.py
+++ b/scripts/eval_regression.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Regression evaluation for OpenDraft golden-topic drafts.
+
+The script can reuse existing draft artifacts for lightweight CI, or generate
+fresh drafts when a generation command is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TOPICS = Path("data/eval_topics.json")
+DEFAULT_OUTPUT = Path("reports/regression_current.json")
+DEFAULT_DRAFTS_DIR = Path("reports/eval_drafts")
+DEFAULT_GENERATE_COMMAND = "opendraft {topic_quoted} --output {output_dir_quoted}"
+REGRESSION_METRICS = ("word_count", "verified_citations", "structure_quality")
+
+
+@dataclass(frozen=True)
+class EvalTopic:
+    id: str
+    topic: str
+    level: str = "research_paper"
+    blurb: str | None = None
+
+
+@dataclass
+class TopicMetrics:
+    topic_id: str
+    topic: str
+    draft_path: str
+    word_count: int
+    citation_count: int
+    verified_citations: int
+    structure_quality: float
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "topic"
+
+
+def load_topics(path: Path) -> list[EvalTopic]:
+    data = json.loads(path.read_text())
+    if not isinstance(data, list) or not data:
+        raise ValueError(f"{path} must contain a non-empty list of topics")
+
+    topics: list[EvalTopic] = []
+    for index, item in enumerate(data, start=1):
+        if isinstance(item, str):
+            topics.append(EvalTopic(id=slugify(item), topic=item))
+            continue
+        if not isinstance(item, dict) or "topic" not in item:
+            raise ValueError(f"Topic #{index} must be a string or object with a 'topic' field")
+        topic = str(item["topic"])
+        topics.append(
+            EvalTopic(
+                id=str(item.get("id") or slugify(topic)),
+                topic=topic,
+                level=str(item.get("level", "research_paper")),
+                blurb=item.get("blurb"),
+            )
+        )
+    return topics
+
+
+def find_draft_file(drafts_dir: Path, topic: EvalTopic) -> Path | None:
+    slug = topic.id or slugify(topic.topic)
+    candidates = [
+        drafts_dir / f"{slug}.md",
+        drafts_dir / f"{slug}.txt",
+        drafts_dir / slug / "final.md",
+        drafts_dir / slug / "draft.md",
+        drafts_dir / slug / "paper.md",
+        drafts_dir / slug / "output.md",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    topic_dir = drafts_dir / slug
+    if topic_dir.is_dir():
+        ranked = sorted(
+            topic_dir.rglob("*.md"),
+            key=lambda path: (
+                not any(token in path.name.lower() for token in ("final", "draft", "paper")),
+                len(path.parts),
+                path.name,
+            ),
+        )
+        if ranked:
+            return ranked[0]
+
+    return None
+
+
+def run_generation(topic: EvalTopic, drafts_dir: Path, command_template: str) -> None:
+    output_dir = drafts_dir / topic.id
+    output_dir.mkdir(parents=True, exist_ok=True)
+    command = command_template.format(
+        topic=topic.topic,
+        topic_quoted=shlex.quote(topic.topic),
+        topic_id=topic.id,
+        output_dir=str(output_dir),
+        output_dir_quoted=shlex.quote(str(output_dir)),
+        level=topic.level,
+        blurb=topic.blurb or "",
+        blurb_quoted=shlex.quote(topic.blurb or ""),
+    )
+    subprocess.run(command, shell=True, check=True)
+
+
+def extract_reference_block(text: str) -> str:
+    match = re.search(r"(?im)^#{1,3}\s+(references|bibliography|works cited)\s*$", text)
+    return text[match.start() :] if match else text
+
+
+def count_words(text: str) -> int:
+    return len(re.findall(r"\b[\w'-]+\b", text))
+
+
+def count_citation_markers(text: str) -> int:
+    patterns = [
+        r"\{cite_[A-Za-z0-9_:-]+\}",
+        r"\[(?:\d+\s*,\s*)*\d+\]",
+        r"\([A-Z][A-Za-z-]+(?:\s+et al\.)?,\s*(?:19|20)\d{2}\)",
+    ]
+    markers: set[str] = set()
+    for pattern in patterns:
+        markers.update(match.group(0) for match in re.finditer(pattern, text))
+    return len(markers)
+
+
+def count_verified_citations_from_text(text: str) -> int:
+    reference_text = extract_reference_block(text)
+    identifiers: set[str] = set()
+    patterns = [
+        r"\b10\.\d{4,9}/[-._;()/:A-Z0-9]+\b",
+        r"\barXiv:\s*\d{4}\.\d{4,5}(?:v\d+)?\b",
+        r"\b(?:https?://)?(?:doi\.org|dx\.doi\.org)/[^\s)]+",
+        r"\b(?:https?://)?(?:openalex\.org|semanticscholar\.org|crossref\.org|pubmed\.ncbi\.nlm\.nih\.gov)/[^\s)]+",
+    ]
+    for pattern in patterns:
+        for match in re.finditer(pattern, reference_text, re.I):
+            identifier = match.group(0).rstrip(".,;").lower()
+            if "doi.org/" in identifier:
+                identifier = identifier.split("doi.org/", 1)[1]
+            identifiers.add(identifier)
+    return len(identifiers)
+
+
+def count_verified_citations_from_database(draft_path: Path) -> int:
+    search_dirs = [draft_path.parent, draft_path.parent.parent]
+    for directory in search_dirs:
+        db_path = directory / "citation_database.json"
+        if not db_path.is_file():
+            continue
+        try:
+            data = json.loads(db_path.read_text())
+        except json.JSONDecodeError:
+            continue
+        citations = data.get("citations", data if isinstance(data, list) else [])
+        if not isinstance(citations, list):
+            continue
+        verified = 0
+        for citation in citations:
+            if not isinstance(citation, dict):
+                continue
+            if citation.get("verified") is True or citation.get("doi") or citation.get("url") or citation.get("source_url"):
+                verified += 1
+        return verified
+    return 0
+
+
+def score_structure_quality(text: str) -> float:
+    headings = re.findall(r"(?m)^#{1,3}\s+(.+?)\s*$", text)
+    normalized = [heading.lower() for heading in headings]
+    expected_sections = (
+        "introduction",
+        "background",
+        "method",
+        "analysis",
+        "discussion",
+        "conclusion",
+        "references",
+    )
+
+    score = 0.0
+    if headings and text.lstrip().startswith("#"):
+        score += 15.0
+
+    covered = sum(1 for section in expected_sections if any(section in heading for heading in normalized))
+    score += (covered / len(expected_sections)) * 55.0
+    score += min(len(headings), 6) / 6 * 15.0
+
+    paragraph_count = len([block for block in re.split(r"\n\s*\n", text.strip()) if len(block.split()) >= 25])
+    score += min(paragraph_count, 6) / 6 * 15.0
+
+    return round(min(score, 100.0), 2)
+
+
+def collect_topic_metrics(topic: EvalTopic, draft_path: Path) -> TopicMetrics:
+    text = draft_path.read_text(encoding="utf-8")
+    db_verified = count_verified_citations_from_database(draft_path)
+    text_verified = count_verified_citations_from_text(text)
+    return TopicMetrics(
+        topic_id=topic.id,
+        topic=topic.topic,
+        draft_path=str(draft_path),
+        word_count=count_words(text),
+        citation_count=count_citation_markers(text),
+        verified_citations=max(db_verified, text_verified),
+        structure_quality=score_structure_quality(text),
+    )
+
+
+def aggregate(metrics: list[TopicMetrics]) -> dict[str, float]:
+    if not metrics:
+        return {metric: 0.0 for metric in REGRESSION_METRICS}
+    return {
+        "word_count": round(sum(item.word_count for item in metrics) / len(metrics), 2),
+        "citation_count": round(sum(item.citation_count for item in metrics) / len(metrics), 2),
+        "verified_citations": round(sum(item.verified_citations for item in metrics) / len(metrics), 2),
+        "structure_quality": round(sum(item.structure_quality for item in metrics) / len(metrics), 2),
+    }
+
+
+def build_report(
+    topics: list[EvalTopic],
+    drafts_dir: Path,
+    generate_command: str | None = None,
+) -> dict[str, Any]:
+    metrics: list[TopicMetrics] = []
+    for topic in topics:
+        if generate_command:
+            run_generation(topic, drafts_dir, generate_command)
+        draft_path = find_draft_file(drafts_dir, topic)
+        if draft_path is None:
+            raise FileNotFoundError(
+                f"No draft found for topic '{topic.id}' in {drafts_dir}. "
+                "Provide existing drafts or pass --generate/--generate-command."
+            )
+        metrics.append(collect_topic_metrics(topic, draft_path))
+
+    return {
+        "topics_file_count": len(topics),
+        "topics": [asdict(item) for item in metrics],
+        "aggregate": aggregate(metrics),
+    }
+
+
+def compare_reports(baseline: dict[str, Any], current: dict[str, Any], max_degradation: float) -> list[dict[str, Any]]:
+    regressions: list[dict[str, Any]] = []
+
+    baseline_aggregate = baseline.get("aggregate", {})
+    current_aggregate = current.get("aggregate", {})
+    for metric in REGRESSION_METRICS:
+        base_value = float(baseline_aggregate.get(metric, 0))
+        current_value = float(current_aggregate.get(metric, 0))
+        if base_value <= 0:
+            continue
+        minimum_allowed = base_value * (1 - max_degradation)
+        if current_value < minimum_allowed:
+            regressions.append(
+                {
+                    "scope": "aggregate",
+                    "metric": metric,
+                    "baseline": base_value,
+                    "current": current_value,
+                    "minimum_allowed": round(minimum_allowed, 2),
+                }
+            )
+
+    baseline_by_topic = {item["topic_id"]: item for item in baseline.get("topics", [])}
+    for item in current.get("topics", []):
+        topic_id = item["topic_id"]
+        baseline_item = baseline_by_topic.get(topic_id)
+        if not baseline_item:
+            continue
+        for metric in REGRESSION_METRICS:
+            base_value = float(baseline_item.get(metric, 0))
+            current_value = float(item.get(metric, 0))
+            if base_value <= 0:
+                continue
+            minimum_allowed = base_value * (1 - max_degradation)
+            if current_value < minimum_allowed:
+                regressions.append(
+                    {
+                        "scope": "topic",
+                        "topic_id": topic_id,
+                        "metric": metric,
+                        "baseline": base_value,
+                        "current": current_value,
+                        "minimum_allowed": round(minimum_allowed, 2),
+                    }
+                )
+
+    return regressions
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run OpenDraft golden-topic regression metrics.")
+    parser.add_argument("--topics", type=Path, default=DEFAULT_TOPICS, help="Path to eval_topics.json")
+    parser.add_argument("--drafts-dir", type=Path, default=DEFAULT_DRAFTS_DIR, help="Directory with generated drafts")
+    parser.add_argument("--baseline", type=Path, help="Baseline JSON report to compare against")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Where to write the current report")
+    parser.add_argument(
+        "--max-degradation",
+        type=float,
+        default=0.10,
+        help="Allowed fractional drop before failing, e.g. 0.10 for 10%%",
+    )
+    parser.add_argument(
+        "--generate",
+        action="store_true",
+        help="Generate drafts using the default opendraft CLI command before measuring",
+    )
+    parser.add_argument(
+        "--generate-command",
+        help=(
+            "Shell command template for generation. Available placeholders: "
+            "{topic_quoted}, {output_dir_quoted}, {topic_id}, {level}, {blurb_quoted}"
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    topics = load_topics(args.topics)
+    command = args.generate_command or (DEFAULT_GENERATE_COMMAND if args.generate else None)
+
+    try:
+        current = build_report(topics, args.drafts_dir, generate_command=command)
+    except Exception as exc:
+        print(f"eval_regression: {exc}", file=sys.stderr)
+        return 2
+
+    regressions: list[dict[str, Any]] = []
+    if args.baseline:
+        baseline = json.loads(args.baseline.read_text())
+        regressions = compare_reports(baseline, current, args.max_degradation)
+
+    current["passed"] = not regressions
+    current["regressions"] = regressions
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(current, indent=2) + "\n")
+
+    print(f"Wrote regression report: {args.output}")
+    print(f"Aggregate metrics: {current['aggregate']}")
+    if regressions:
+        print(f"Regression check failed: {len(regressions)} metric(s) degraded", file=sys.stderr)
+        return 1
+    print("Regression check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_eval_regression.py
+++ b/tests/test_eval_regression.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+
+from scripts.eval_regression import (
+    EvalTopic,
+    build_report,
+    compare_reports,
+    count_verified_citations_from_text,
+    load_topics,
+    main,
+    score_structure_quality,
+)
+
+
+SAMPLE_DRAFT = """# Citation Integrity in AI Writing
+
+## Introduction
+
+This paper studies source-grounded writing and citation verification in AI-assisted
+research workflows. It introduces a repeatable benchmark for citation integrity
+and discusses why generated drafts need automated regression checks.
+
+## Background
+
+Prior work shows that language models can produce fluent claims with unsupported
+references. OpenDraft mitigates this by validating sources against scholarly
+databases and by keeping source metadata attached to generated sections.
+
+## Method
+
+We evaluate drafts with fixed golden topics, a word-count target, citation
+coverage, and a structure score. The evaluation includes references such as
+Smith (2024) and {cite_001}.
+
+## Analysis
+
+The benchmark compares the current draft set against a previous baseline.
+Metric drops greater than ten percent should fail CI because they indicate
+potentially meaningful regressions in source quality or structure.
+
+## Discussion
+
+Regression checks are especially useful for prompts and agent orchestration
+because changes can alter output quality without changing unit-test behavior.
+
+## Conclusion
+
+Golden-topic evaluation gives maintainers a stable signal for release quality.
+
+## References
+
+Smith, J. (2024). Citation verification for generated drafts.
+https://doi.org/10.1234/example.doi
+"""
+
+
+def test_load_topics_accepts_objects_and_strings(tmp_path: Path) -> None:
+    topics_file = tmp_path / "topics.json"
+    topics_file.write_text(json.dumps([{"id": "one", "topic": "Topic One"}, "Topic Two"]))
+
+    topics = load_topics(topics_file)
+
+    assert [topic.id for topic in topics] == ["one", "topic-two"]
+    assert topics[0].topic == "Topic One"
+
+
+def test_metrics_extract_verified_citations_and_structure() -> None:
+    assert count_verified_citations_from_text(SAMPLE_DRAFT) == 1
+    assert score_structure_quality(SAMPLE_DRAFT) >= 80
+
+
+def test_build_report_from_existing_drafts(tmp_path: Path) -> None:
+    drafts_dir = tmp_path / "drafts"
+    drafts_dir.mkdir()
+    (drafts_dir / "citation-integrity.md").write_text(SAMPLE_DRAFT)
+
+    report = build_report([EvalTopic(id="citation-integrity", topic="Citation integrity")], drafts_dir)
+
+    assert report["aggregate"]["word_count"] > 100
+    assert report["aggregate"]["verified_citations"] == 1
+    assert report["topics"][0]["draft_path"].endswith("citation-integrity.md")
+
+
+def test_compare_reports_fails_on_metric_degradation() -> None:
+    baseline = {
+        "aggregate": {"word_count": 1000, "verified_citations": 10, "structure_quality": 90},
+        "topics": [
+            {"topic_id": "one", "word_count": 1000, "verified_citations": 10, "structure_quality": 90}
+        ],
+    }
+    current = {
+        "aggregate": {"word_count": 800, "verified_citations": 10, "structure_quality": 90},
+        "topics": [
+            {"topic_id": "one", "word_count": 1000, "verified_citations": 8, "structure_quality": 90}
+        ],
+    }
+
+    regressions = compare_reports(baseline, current, max_degradation=0.10)
+
+    assert {item["metric"] for item in regressions} == {"word_count", "verified_citations"}
+
+
+def test_main_writes_report(tmp_path: Path) -> None:
+    topics_file = tmp_path / "topics.json"
+    topics_file.write_text(json.dumps([{"id": "citation-integrity", "topic": "Citation integrity"}]))
+    drafts_dir = tmp_path / "drafts"
+    drafts_dir.mkdir()
+    (drafts_dir / "citation-integrity.md").write_text(SAMPLE_DRAFT)
+    output = tmp_path / "report.json"
+
+    exit_code = main(["--topics", str(topics_file), "--drafts-dir", str(drafts_dir), "--output", str(output)])
+
+    assert exit_code == 0
+    data = json.loads(output.read_text())
+    assert data["passed"] is True


### PR DESCRIPTION
## Summary
- add `data/eval_topics.json` with five golden topics for citation-quality regression checks
- add `scripts/eval_regression.py` to measure word count, verified citations, citation markers, and structure quality
- support existing draft artifacts for lightweight CI and optional generation via `--generate` / `--generate-command`
- document the regression workflow in `EVALUATION.md`
- add unit tests for topic loading, metric extraction, regression comparison, and report writing

Closes #34

## Verification
- `.venv/bin/python -m pytest tests/test_eval_regression.py -q`
- `.venv/bin/python -m ruff check scripts/eval_regression.py tests/test_eval_regression.py`
- `.venv/bin/python -m py_compile scripts/eval_regression.py tests/test_eval_regression.py`
- `.venv/bin/python scripts/eval_regression.py --help`

## Note
- I did not run live draft generation because it requires configured API credentials. The script supports that path with `--generate`; the tests exercise the offline artifact mode intended for CI.