### PR TITLE
fix: retry CrossRef DOI validation

### DIFF
--- a/engine/utils/citation_validator.py
+++ b/engine/utils/citation_validator.py
@@ -5,12 +5,21 @@ ABOUTME: Uses CrossRef API to verify DOIs, URL status checks, and metadata quali
 """
 
 import json
+import logging
 import re
 import requests
 from pathlib import Path
 from typing import List, Dict, Tuple, Optional
 from dataclasses import dataclass
-from urllib.parse import urlparse
+
+from utils.retry import retry
+
+
+logger = logging.getLogger(__name__)
+
+
+class _RetryableCrossrefError(requests.HTTPError):
+    """CrossRef returned a transient status that should be retried."""
 
 
 @dataclass
@@ -36,6 +45,44 @@ class CitationValidator:
         self.timeout = timeout
         self.crossref_api_base = "https://api.crossref.org/works/"
 
+    @retry(
+        max_attempts=3,
+        base_delay=0.5,
+        max_delay=4.0,
+        exceptions=(
+            requests.exceptions.RequestException,
+            _RetryableCrossrefError,
+        ),
+    )
+    def _get_crossref_work(self, doi_clean: str) -> requests.Response:
+        """Fetch a CrossRef work, retrying transient failures with backoff."""
+        response = requests.get(
+            f"{self.crossref_api_base}{doi_clean}",
+            timeout=self.timeout,
+            headers={
+                'User-Agent': (
+                    'OpenDraft/1.3 '
+                    '(https://github.com/federicodeponte/opendraft)'
+                )
+            }
+        )
+
+        if response.status_code == 429 or response.status_code >= 500:
+            logger.warning(
+                (
+                    "CrossRef DOI validation got HTTP %s for %s; "
+                    "retrying if attempts remain"
+                ),
+                response.status_code,
+                doi_clean,
+            )
+            raise _RetryableCrossrefError(
+                f"CrossRef transient response: HTTP {response.status_code}",
+                response=response,
+            )
+
+        return response
+
     def validate_doi(self, doi: str) -> Optional[bool]:
         """
         Verify if a DOI exists via CrossRef API.
@@ -47,14 +94,13 @@ class CitationValidator:
             True if DOI exists, False if DOI not found (404), None if network error
         """
         # Clean DOI (remove prefix if present)
-        doi_clean = doi.replace('https://doi.org/', '').replace('http://doi.org/', '')
+        doi_clean = doi.replace('https://doi.org/', '').replace(
+            'http://doi.org/',
+            '',
+        )
 
         try:
-            response = requests.get(
-                f"{self.crossref_api_base}{doi_clean}",
-                timeout=self.timeout,
-                headers={'User-Agent': 'OpenDraft/1.3 (https://github.com/federicodeponte/opendraft)'}
-            )
+            response = self._get_crossref_work(doi_clean)
             return response.status_code == 200
         except requests.exceptions.RequestException:
             # Network error - assume DOI might be valid

--- a/tests/test_citation_validator.py
+++ b/tests/test_citation_validator.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tests for offline citation validator behavior
+ABOUTME: Covers CrossRef DOI retry handling for transient API failures
+"""
+
+import os
+import sys
+
+import requests
+
+# Add engine directory to path so utils can be imported
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'engine'))
+
+from utils.citation_validator import CitationValidator  # noqa: E402
+
+
+class StubResponse:
+    """Small response double for DOI validator tests."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def test_validate_doi_retries_timeout_then_success(monkeypatch):
+    """CrossRef DOI validation should retry transient network failures."""
+    responses = [requests.exceptions.Timeout("timed out"), StubResponse(200)]
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        result = responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert CitationValidator(timeout=1).validate_doi("10.1000/example") is True
+    assert len(calls) == 2
+
+
+def test_validate_doi_returns_unknown_after_retry_exhaustion(monkeypatch):
+    """Persistent CrossRef network errors should preserve unknown DOI status."""
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise requests.exceptions.ConnectionError("connection failed")
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert CitationValidator(timeout=1).validate_doi("10.1000/flaky") is None
+    assert len(calls) == 3
+
+
+def test_validate_doi_retries_rate_limit_then_success(monkeypatch):
+    """HTTP 429 from CrossRef should be treated as transient."""
+    responses = [StubResponse(429), StubResponse(200)]
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert (
+        CitationValidator(timeout=1).validate_doi("10.1000/rate-limited")
+        is True
+    )
+    assert len(calls) == 2
+
+
+def test_validate_doi_retries_server_error_then_success(monkeypatch):
+    """CrossRef 5xx responses should be retried before falling back."""
+    responses = [StubResponse(503), StubResponse(200)]
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return responses.pop(0)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert (
+        CitationValidator(timeout=1).validate_doi("10.1000/server-error")
+        is True
+    )
+    assert len(calls) == 2
+
+
+def test_validate_doi_does_not_retry_not_found(monkeypatch):
+    """HTTP 404 means the DOI was not found and should not be retried."""
+    calls = []
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return StubResponse(404)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    assert (
+        CitationValidator(timeout=1).validate_doi("10.1000/missing")
+        is False
+    )
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- add retry/backoff around CrossRef DOI validation in `CitationValidator`
- treat HTTP 429 and 5xx CrossRef responses as transient retryable failures
- add offline unit coverage for timeout, retry exhaustion, 429, 5xx, and 404 behavior

## Why
CrossRef DOI checks currently make a single direct `requests.get` call, so short-lived rate limits or network errors can immediately become `doi_check_failed` warnings. The validator now reuses the existing retry helper before falling back to the previous unknown-result behavior.

## Tests
- `.venv/bin/python -m pytest tests/test_citation_validator.py tests/test_retry.py -q`
- `.venv/bin/python -m pytest tests/test_citation_validator.py tests/test_ticket003_citation_mismatch.py tests/test_citation_styles.py -q`
- `.venv/bin/python -m compileall -q engine/utils/citation_validator.py tests/test_citation_validator.py`
- `.venv/bin/python -m flake8 --max-line-length=100 --extend-ignore=E203,E266,E501,W503 engine/utils/citation_validator.py tests/test_citation_validator.py`
- `git diff --check`

Closes #36
