### PR TITLE
feat(config): make API base URLs and model names configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,18 @@ GOOGLE_API_KEY=your-gemini-api-key
 # ANTHROPIC_API_KEY=your-claude-api-key
 # OPENAI_API_KEY=your-openai-api-key
 
+# Optional: Override API base URLs (for proxies, gateways, or self-hosted endpoints)
+# Defaults shown below; leave unset to use the official endpoints.
+# ANTHROPIC_BASE_URL=https://api.anthropic.com
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Optional: Select provider and per-provider model name
+# AI_PROVIDER controls which provider is used (gemini | openai | claude)
+# AI_PROVIDER=gemini
+# GEMINI_MODEL=gemini-3-pro-preview
+# OPENAI_MODEL=gpt-4.1-nano
+# ANTHROPIC_MODEL=claude-sonnet-4-6
+
 # Optional: Fallback Gemini API keys for rate limit resilience
 # GOOGLE_API_KEY_FALLBACK=your-fallback-key
 # GOOGLE_API_KEY_FALLBACK_2=your-second-fallback-key

--- a/engine/config.py
+++ b/engine/config.py
@@ -33,6 +33,29 @@ except ImportError:
     pass
 
 
+# Default model name per provider (used when no provider-specific env var is set)
+_DEFAULT_MODELS = {
+    'gemini': 'gemini-3-pro-preview',
+    'openai': 'gpt-4.1-nano',
+    'claude': 'claude-sonnet-4-6',
+}
+
+# Env var holding the model name for each provider
+_MODEL_ENV_VARS = {
+    'gemini': 'GEMINI_MODEL',
+    'openai': 'OPENAI_MODEL',
+    'claude': 'ANTHROPIC_MODEL',
+}
+
+
+def _default_model_name() -> str:
+    """Resolve the model name from the provider-specific env var, with a sensible default."""
+    provider = os.getenv('AI_PROVIDER', 'gemini')
+    env_var = _MODEL_ENV_VARS.get(provider, 'GEMINI_MODEL')
+    default = _DEFAULT_MODELS.get(provider, _DEFAULT_MODELS['gemini'])
+    return os.getenv(env_var, default)
+
+
 @dataclass
 class ModelConfig:
     """
@@ -43,13 +66,7 @@ class ModelConfig:
     provider: Literal['gemini', 'claude', 'openai'] = field(
         default_factory=lambda: os.getenv('AI_PROVIDER', 'gemini')
     )
-    model_name: str = field(
-        default_factory=lambda: (
-            os.getenv('OPENAI_MODEL', 'gpt-4.1-nano')
-            if os.getenv('AI_PROVIDER') == 'openai'
-            else os.getenv('GEMINI_MODEL', 'gemini-3-pro-preview')
-        )
-    )
+    model_name: str = field(default_factory=lambda: _default_model_name())
     temperature: float = 0.7
     max_output_tokens: Optional[int] = None
     api_key: Optional[str] = None
@@ -66,20 +83,19 @@ class ModelConfig:
             'gemini-1.5-pro',
         ]
 
-        valid_openai_models = [
-            'gpt-4.1-nano',
-        ]
-
         if self.provider == 'gemini' and self.model_name not in valid_gemini_models:
             raise ValueError(
                 f"Invalid Gemini model: {self.model_name}. "
                 f"Valid options: {', '.join(valid_gemini_models)}"
             )
 
-        if self.provider == 'openai' and self.model_name not in valid_openai_models:
+        # OpenAI and Claude model names are not whitelisted: with a configurable
+        # base URL (proxies, gateways, self-hosted endpoints) the set of valid
+        # names is open-ended. Just require a non-empty value.
+        if self.provider in ('openai', 'claude') and not self.model_name:
             raise ValueError(
-                f"Invalid OpenAI model: {self.model_name}. "
-                f"Valid options: {', '.join(valid_openai_models)}"
+                f"A model name is required for the '{self.provider}' provider. "
+                f"Set {_MODEL_ENV_VARS[self.provider]} in your .env file."
             )
 
 
@@ -128,6 +144,14 @@ class AppConfig:
     google_api_key_fallback_3: str = field(default_factory=lambda: os.getenv('GOOGLE_API_KEY_FALLBACK_3', ''))
     anthropic_api_key: str = field(default_factory=lambda: os.getenv('ANTHROPIC_API_KEY', ''))
     openai_api_key: str = field(default_factory=lambda: os.getenv('OPENAI_API_KEY', ''))
+
+    # API base URLs (configurable for proxies, gateways, or self-hosted endpoints)
+    anthropic_base_url: str = field(
+        default_factory=lambda: os.getenv('ANTHROPIC_BASE_URL', 'https://api.anthropic.com')
+    )
+    openai_base_url: str = field(
+        default_factory=lambda: os.getenv('OPENAI_BASE_URL', 'https://api.openai.com/v1')
+    )
 
     # Sub-configurations
     model: ModelConfig = field(default_factory=ModelConfig)


### PR DESCRIPTION
## Summary

Makes the Anthropic and OpenAI API base URLs configurable via environment
variables (with sensible defaults), and reworks model-name resolution so each
provider has its own configurable model name. This unblocks using proxies,
gateways, or self-hosted/OpenAI-compatible endpoints without code changes.

## Changes

- **Configurable base URLs** — add `anthropic_base_url` and `openai_base_url`
  to `AppConfig`, sourced from `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` and
  defaulting to the official endpoints (`https://api.anthropic.com`,
  `https://api.openai.com/v1`).
- **Per-provider model names** — replace the gemini/openai-only model selector
  with a `_default_model_name()` resolver driven by `AI_PROVIDER`, reading
  `GEMINI_MODEL` / `OPENAI_MODEL` / `ANTHROPIC_MODEL`. Fixes a gap where the
  `claude` provider had no model env var and silently fell back to the Gemini
  default.
- **Relaxed validation** — drop the hard-coded OpenAI model whitelist (it only
  permitted `gpt-4.1-nano`, which conflicts with custom/gateway endpoints).
  OpenAI and Claude now just require a non-empty model name; the Gemini
  whitelist is unchanged.
- **Docs** — document the new variables in `.env.example`.

## Defaults / backwards compatibility

All new variables are optional and fall back to the previous behavior, so
existing Gemini-based setups are unaffected.

## Notes

These values are now available on `get_config()`, but no Anthropic/OpenAI
client is wired into the generation pipeline yet — the active path remains
Gemini. This PR is the config groundwork for that future wiring.
