### PR TITLE
fix: retry transient CrossRef DOI failures

### DIFF
--- a/engine/utils/citation_validator.py
+++ b/engine/utils/citation_validator.py
@@ -102,8 +102,9 @@ class CitationValidator:
         try:
             response = self._get_crossref_work(doi_clean)
             return response.status_code == 200
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as exc:
             # Network error - assume DOI might be valid
+            logger.warning("CrossRef DOI validation failed after retries for %s: %s", doi_clean, exc)
             return None  # Unknown
 
     def check_author_sanity(self, authors: List[str]) -> List[str]:

--- a/tests/test_citation_validator.py
+++ b/tests/test_citation_validator.py
@@ -4,6 +4,7 @@ ABOUTME: Tests for offline citation validator behavior
 ABOUTME: Covers CrossRef DOI retry handling for transient API failures
 """
 
+import logging
 import os
 import sys
 
@@ -40,7 +41,7 @@ def test_validate_doi_retries_timeout_then_success(monkeypatch):
     assert len(calls) == 2
 
 
-def test_validate_doi_returns_unknown_after_retry_exhaustion(monkeypatch):
+def test_validate_doi_returns_unknown_after_retry_exhaustion(monkeypatch, caplog):
     """Persistent CrossRef network errors should preserve unknown DOI status."""
     calls = []
 
@@ -50,8 +51,11 @@ def test_validate_doi_returns_unknown_after_retry_exhaustion(monkeypatch):
 
     monkeypatch.setattr(requests, "get", fake_get)
 
-    assert CitationValidator(timeout=1).validate_doi("10.1000/flaky") is None
+    with caplog.at_level(logging.WARNING, logger="utils.citation_validator"):
+        assert CitationValidator(timeout=1).validate_doi("10.1000/flaky") is None
+
     assert len(calls) == 3
+    assert "CrossRef DOI validation failed after retries" in caplog.text
 
 
 def test_validate_doi_retries_rate_limit_then_success(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds tenacity retry handling around CrossRef DOI validation requests.
- Retries transient 429/5xx responses and timeout/connection failures with exponential backoff.
- Logs a warning when DOI validation still fails after retries and keeps validation conservative by returning unknown.
- Adds focused unit tests for retry success, retry exhaustion logging, and non-retry 404 behavior.

Closes #36

## Verification
- python -m pytest tests/test_citation_styles.py tests/test_ticket003_citation_mismatch.py tests/test_citation_validator.py
- python -m compileall engine/utils/citation_validator.py tests/test_citation_validator.py