### PR TITLE
fix(ci): stabilize quality gate tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ logs/
 tmp/
 temp/
 *.tmp
+WORKPLAN-*.md
 
 # Test outputs
 tests/outputs/

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -160,16 +160,17 @@ class TestDigestOutput:
         mock_response = Mock()
         mock_response.text = "This is a test digest script about research findings and their implications for the field."
 
-        with patch('digest.GeminiModelWrapper') as MockModel:
-            mock_instance = MockModel.return_value
-            mock_instance.generate_content.return_value = mock_response
+        with patch.dict(os.environ, {"GOOGLE_API_KEY": "test-key"}):
+            with patch('digest.GeminiModelWrapper') as MockModel:
+                mock_instance = MockModel.return_value
+                mock_instance.generate_content.return_value = mock_response
 
-            with patch('google.genai'):
-                result = generate_digest(
-                    doc,
-                    output_dir=output_dir,
-                    generate_audio=False  # Skip audio for unit test
-                )
+                with patch('google.genai'):
+                    result = generate_digest(
+                        doc,
+                        output_dir=output_dir,
+                        generate_audio=False  # Skip audio for unit test
+                    )
 
         assert "script" in result
         assert "script_path" in result

--- a/tests/test_e2e_subprocess_kill.py
+++ b/tests/test_e2e_subprocess_kill.py
@@ -44,9 +44,11 @@ import sys
 import time
 import json
 import signal
+import os
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "engine"))
+REPO_ROOT = Path(os.environ.get("OPENDRAFT_TEST_REPO_ROOT", Path.cwd())).resolve()
+sys.path.insert(0, str(REPO_ROOT / "engine"))
 
 from utils.checkpoint import save_checkpoint, load_checkpoint, restore_context, get_next_phase, PHASES
 from utils.citation_database import Citation
@@ -151,7 +153,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     import os
-    os.chdir(Path(__file__).parent.parent)  # CD to opendraft root
+    os.chdir(REPO_ROOT)  # CD to opendraft root
 
     success = run_mock_pipeline(
         output_dir=Path(args.output_dir),
@@ -175,6 +177,12 @@ class TestTrueE2ESubprocessKill:
         script_path = tmp_path / "mock_pipeline.py"
         script_path.write_text(MOCK_PIPELINE_SCRIPT)
         return script_path
+
+    def _subprocess_env(self) -> dict:
+        """Return environment for mock pipeline subprocesses."""
+        env = os.environ.copy()
+        env["OPENDRAFT_TEST_REPO_ROOT"] = str(Path(__file__).parent.parent)
+        return env
 
     def _wait_for_phase(self, output_dir: Path, phase: str, timeout: float = 10.0) -> bool:
         """Wait for a phase to start (marker file appears)."""
@@ -210,6 +218,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         try:
@@ -238,6 +247,7 @@ class TestTrueE2ESubprocessKill:
                 stderr=subprocess.PIPE,
                 text=True,
                 cwd=str(Path(__file__).parent.parent),
+                env=self._subprocess_env(),
             )
 
             stdout, _ = proc2.communicate(timeout=30)
@@ -258,6 +268,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         try:
@@ -291,6 +302,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         stdout, stderr = proc2.communicate(timeout=30)
@@ -313,6 +325,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         try:
@@ -348,6 +361,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         stdout, _ = proc2.communicate(timeout=30)
@@ -369,6 +383,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         try:
@@ -410,6 +425,7 @@ class TestTrueE2ESubprocessKill:
                 stderr=subprocess.PIPE,
                 text=True,
                 cwd=str(Path(__file__).parent.parent),
+                env=self._subprocess_env(),
             )
 
             try:
@@ -443,6 +459,7 @@ class TestTrueE2ESubprocessKill:
             stderr=subprocess.PIPE,
             text=True,
             cwd=str(Path(__file__).parent.parent),
+            env=self._subprocess_env(),
         )
 
         stdout, _ = proc.communicate(timeout=60)


### PR DESCRIPTION
## Summary
- fix the digest unit test so it supplies a dummy Google API key and reaches the mocked Gemini wrapper
- fix the subprocess e2e mock pipeline so temp scripts import engine modules from the repository root
- add the local workplan filename pattern to gitignore

## Root cause
Quality Gates run 28123747924 failed in pytest. The digest test raised `ValueError: GOOGLE_API_KEY or GEMINI_API_KEY required` before its Gemini mock could run. The subprocess kill/resume tests generated `mock_pipeline.py` in a pytest temp directory, then resolved `Path(__file__).parent.parent / "engine"`, so the child process could not import the engine and never wrote phase markers/checkpoints.

## Verification
- `env -u GOOGLE_API_KEY -u GEMINI_API_KEY -u GOOGLE_GENERATIVE_AI_API_KEY .venv-ci/bin/python -m pytest tests/test_digest.py::TestDigestOutput::test_generate_digest_creates_files tests/test_e2e_subprocess_kill.py -q` -> 14 passed
- full local Quality Gates sequence with Google/Gemini env vars unset -> 456 passed, 10 skipped, 6 deselected
