### PR TITLE
fix(packaging): ship prompts in the wheel (Scribe FileNotFoundError, 1.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes are documented in this file.
 
+## 1.7.3 - 2026-07-20
+
+### Fixed
+- P1: `pip install opendraft` shipped no prompt files, so the Scribe phase crashed
+  with `FileNotFoundError` loading `prompts/01_research/scribe.md` right after the
+  Scout/citation phase succeeded (reinstalling did not help). The prompt markdown
+  lived in a top-level `prompts/` directory that was never declared as package data
+  for the wheel built from `engine/pyproject.toml` (only the sdist-only `opendraft`
+  glob was set). This is a regression of issue #26. The `prompts/` directory is now
+  a proper `prompts` package shipped as package data in both the wheel and the sdist,
+  and `load_prompt` resolves prompts via `importlib.resources` with filesystem
+  fallbacks so it works from an installed wheel, a source checkout, or zipimport.
+- Scout "Success Rate" could exceed 100% (e.g. 190%) because it divided total
+  citations by the number of research topics. It now reports the fraction of topics
+  that yielded at least one citation, capped at 100%.
+
+### Guarded
+- Added regression tests that assert the real PyPI publisher (`engine/pyproject.toml`)
+  ships the prompts and that `prompts/__init__.py` exists.
+
 ## 2026-02-16
 
 ### Added

--- a/engine/MANIFEST.in
+++ b/engine/MANIFEST.in
@@ -1,0 +1,5 @@
+# Ensure prompt markdown files ship in the sdist as well as the wheel.
+# (package-data in pyproject.toml covers the wheel; MANIFEST.in covers the sdist.)
+recursive-include prompts *.md
+graft prompts
+global-exclude __pycache__ *.py[cod]

--- a/engine/opendraft/version.py
+++ b/engine/opendraft/version.py
@@ -1,4 +1,4 @@
 """Version information for OpenDraft."""
 
-__version__ = "1.6.23"
+__version__ = "1.7.3"
 __version_info__ = tuple(int(i) for i in __version__.split(".") if i.isdigit())

--- a/engine/prompts/__init__.py
+++ b/engine/prompts/__init__.py
@@ -1,0 +1,10 @@
+"""OpenDraft agent prompt library.
+
+This package exists so the prompt markdown files (loaded at runtime by the
+scribe/scout/compose/validate phases) are collected as package data and shipped
+in the built wheel. Without it, `pip install opendraft` omits the prompts and
+the scribe phase raises FileNotFoundError (issue #26).
+
+Prompt files are addressed by relative path, e.g. "01_research/scribe.md";
+resolution is centralized in utils.agent_runner.load_prompt.
+"""

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendraft"
-version = "1.7.2"
+version = "1.7.3"
 description = "Generate master-level research papers with real citations in minutes"
 readme = "README.md"
 license = {text = "MIT"}
@@ -95,13 +95,18 @@ opendraft-digest = "digest:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["opendraft*", "utils*", "concurrency*", "phases*"]
+include = ["opendraft*", "utils*", "concurrency*", "phases*", "prompts*"]
 
 [tool.setuptools]
 py-modules = ["config", "draft_generator", "tldr", "digest"]
 include-package-data = true
 
 [tool.setuptools.package-data]
+# Prompt markdown files live in the top-level `prompts/` package and are loaded
+# at runtime by the scribe/scout/compose phases. They MUST ship in the wheel
+# (not just the sdist) or the engine raises FileNotFoundError after install.
+# See issue #26 (regressed in 1.7.2, refixed in 1.7.3).
+"prompts" = ["*.md", "*/*.md", "**/*.md"]
 "opendraft" = ["prompts/*.md", "prompts/**/*.md"]
 "*" = ["*.md"]
 

--- a/engine/utils/agent_runner.py
+++ b/engine/utils/agent_runner.py
@@ -12,6 +12,7 @@ import time
 import logging
 import os
 import json
+import importlib.resources as _ir
 from pathlib import Path
 from typing import Optional, Callable, Tuple, List, TYPE_CHECKING, Any, Dict
 from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError as FuturesTimeoutError
@@ -86,9 +87,45 @@ def setup_model(model_override: Optional[str] = None) -> Any:
     )
 
 
+def _load_prompt_via_resources(prompt_path: str) -> Optional[str]:
+    """Load a prompt from the installed `prompts` package via importlib.resources.
+
+    Robust for wheels / zipimport / relocated installs where a filesystem path
+    relative to a source module does not resolve. Prompt paths are addressed like
+    "prompts/01_research/scribe.md" (or the test form "engine/prompts/..."); we
+    strip everything up to and including the last "prompts/" segment to get the
+    path relative to the `prompts` package root.
+    """
+    normalized = prompt_path.replace("\\", "/")
+    marker = "prompts/"
+    idx = normalized.rfind(marker)
+    rel = normalized[idx + len(marker):] if idx != -1 else normalized
+    if not rel:
+        return None
+    try:
+        root = _ir.files("prompts")
+    except (ModuleNotFoundError, ImportError, TypeError):
+        return None
+    resource = root.joinpath(rel)
+    try:
+        if resource.is_file():
+            return resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return None
+    return None
+
+
 def load_prompt(prompt_path: str) -> str:
     """
     Load agent prompt from markdown file.
+
+    Resolution order (first hit wins), so the engine works both from a source
+    checkout AND from a pip-installed wheel:
+      1. Absolute path as given.
+      2. Filesystem paths relative to the engine root / project root / cwd
+         (dev tree + flat installs).
+      3. The shipped `prompts` package via importlib.resources
+         (installed wheels, zipimport, relocated installs).
 
     Args:
         prompt_path: Path to prompt file (relative to project root or absolute)
@@ -97,20 +134,36 @@ def load_prompt(prompt_path: str) -> str:
         str: Content of the prompt file
 
     Raises:
-        FileNotFoundError: If prompt file doesn't exist
+        FileNotFoundError: If prompt file cannot be found in any location.
     """
     config = get_config()
     path = Path(prompt_path)
+    tried: List[str] = []
 
-    # If relative path, try relative to project root
-    if not path.is_absolute():
-        path = config.paths.project_root / path
+    if path.is_absolute():
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+        tried.append(str(path))
+    else:
+        candidates = [
+            config.paths.project_root / path,                 # dir containing config.py
+            Path(__file__).resolve().parent.parent / path,    # engine/ root
+            Path.cwd() / path,                                 # current working dir
+        ]
+        for cand in candidates:
+            if cand.exists():
+                return cand.read_text(encoding="utf-8")
+            tried.append(str(cand))
 
-    if not path.exists():
-        raise FileNotFoundError(f"Prompt file not found: {path}")
+    # Fall back to the packaged `prompts` resources (installed wheel case).
+    via_pkg = _load_prompt_via_resources(prompt_path)
+    if via_pkg is not None:
+        return via_pkg
+    tried.append(f"importlib.resources('prompts')::{prompt_path}")
 
-    with open(path, 'r', encoding='utf-8') as f:
-        return f.read()
+    raise FileNotFoundError(
+        f"Prompt file not found: {prompt_path}. Tried: {'; '.join(tried)}"
+    )
 
 
 def run_agent(
@@ -1063,7 +1116,13 @@ def research_citations_via_api(
 
     # Calculate success metrics
     citation_count = len(citations)
-    success_rate = (citation_count / len(research_topics) * 100) if research_topics else 0
+    # Success rate = fraction of research topics that yielded at least one
+    # citation, NOT total citations / topics (a single topic can produce
+    # multiple citations, which previously pushed the "rate" above 100%,
+    # e.g. 19 citations / 10 topics -> 190%).
+    total_topics = len(research_topics) if research_topics else 0
+    successful_topics = max(total_topics - len(failed_topics), 0)
+    success_rate = (successful_topics / total_topics * 100) if total_topics else 0
 
     if verbose:
         safe_print("\n" + "=" * 80)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendraft"
-version = "1.7.2"
+version = "1.7.3"
 description = "Open-source AI research draft generator with 19 specialized agents and verified citations"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_packaging_subpackages.py
+++ b/tests/test_packaging_subpackages.py
@@ -13,11 +13,59 @@ from pathlib import Path
 # Add repo root to path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
+# The wheel published to PyPI is built from engine/pyproject.toml (flat layout,
+# defines the console entry points). Issue #26 regressed in 1.7.2 because only
+# the root pyproject.toml was guarded while the ENGINE one silently dropped the
+# prompts. Guard the real publisher too.
+ENGINE_PYPROJECT = REPO_ROOT / "engine" / "pyproject.toml"
 
 
 def _load_pyproject() -> dict:
     with open(PYPROJECT, "rb") as f:
         return tomllib.load(f)
+
+
+def _load_engine_pyproject() -> dict:
+    with open(ENGINE_PYPROJECT, "rb") as f:
+        return tomllib.load(f)
+
+
+def test_engine_pyproject_ships_prompts_in_wheel():
+    """engine/pyproject.toml (the real PyPI publisher) must ship the prompts.
+
+    Regression guard for issue #26 re-occurring in 1.7.2: the flat `engine`
+    build declared package-data only for the `opendraft` package, but the
+    prompts live in a sibling `prompts/` dir. They were dropped from the wheel
+    and the scribe phase raised FileNotFoundError after `pip install`.
+
+    The fix ships prompts as their own `prompts` package: it must appear in
+    packages.find include AND have a `.md` package-data glob.
+    """
+    cfg = _load_engine_pyproject()
+    setuptools = cfg.get("tool", {}).get("setuptools", {})
+
+    find_include = setuptools.get("packages", {}).get("find", {}).get("include", [])
+    assert any(g.startswith("prompts") for g in find_include), (
+        "engine/pyproject.toml packages.find must include 'prompts*' so the "
+        f"prompts package is discovered and shipped. Got: {find_include}"
+    )
+
+    pkg_data = setuptools.get("package-data", {})
+    prompt_globs = pkg_data.get("prompts", [])
+    assert any(g.endswith(".md") for g in prompt_globs), (
+        "engine/pyproject.toml package-data must include a prompts '*.md' glob so "
+        f"the markdown prompts land in the wheel. Got: {prompt_globs}"
+    )
+
+
+def test_prompts_is_an_importable_package():
+    """The prompts dir must be a real package (have __init__.py) so setuptools
+    collects its data files into the wheel."""
+    init_file = REPO_ROOT / "engine" / "prompts" / "__init__.py"
+    assert init_file.is_file(), (
+        f"Missing {init_file}: without it setuptools will not ship the prompt "
+        "markdown files in the wheel (issue #26)."
+    )
 
 
 def test_pyproject_uses_find_or_lists_all_subpackages():


### PR DESCRIPTION
## P1: `pip install opendraft` crashes in the Scribe phase

A pip-installed user (Windows, Py3.14) hit `FileNotFoundError` loading `prompts/01_research/scribe.md` right after Scout succeeded; reinstalling did not fix it.

### Root cause
The PyPI wheel is built from `engine/pyproject.toml` (flat layout, defines the console scripts). The prompt markdown lives in a **sibling** `engine/prompts/` directory that was never declared as package data for that build, so every prompt was dropped from the wheel. Confirmed: 1.7.2 ships **0** `.md` prompts. This is a regression of #26 (the earlier fix only guarded the root `pyproject.toml`, which is not the publisher and has no `[project.scripts]`).

### Fix
- `prompts/` is now a real `prompts` package (added `__init__.py`) shipped as package data in the wheel (`pyproject.toml`) and sdist (`MANIFEST.in`).
- `load_prompt` hardened to resolve via filesystem candidates **and** `importlib.resources` (works from wheel, source checkout, or zipimport).
- Scout "Success Rate" no longer exceeds 100% (was total-citations/topics -> 190%; now topics-with-a-hit/topics).
- Bumped 1.7.2 -> 1.7.3 (+ version.py, changelog), added regression tests guarding the real publisher.

### Verification (clean venv of the BUILT wheel)
- 25/25 prompts present in wheel **and** sdist, including `01_research/scribe.md`.
- Old 1.7.2 confirmed to fail the exact call; new wheel loads scribe/scout/crafter/titlemaker/tldr + importlib fallback.
- `tldr`/`digest` import (they read prompts at import time); `__version__` reports 1.7.3.
- 5/5 packaging regression tests pass.

Blocked: `twine upload` to PyPI needs Federico's PyPI token (not present on the build host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)