### PR TITLE
feat(export): add compilable LaTeX (.tex) output (v1.7.4)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,21 +31,30 @@ jobs:
       - name: Build sdist and wheel
         run: |
           python -m pip install --upgrade build twine
-          python -m build
+          # The distributable project lives in engine/ (flat layout: opendraft,
+          # utils, phases, prompts, ...). Building the repo ROOT instead produces
+          # an engine/-nested wheel where `import opendraft` fails (the 1.7.2
+          # breakage). Always build from engine/ into the top-level dist/.
+          rm -rf dist
+          python -m build --outdir dist engine
 
-      - name: Verify prompts are bundled (guards the 1.7.3 packaging bug)
+      - name: Verify wheel is the correct flat layout (guards the 1.7.2/1.7.3 packaging bug)
         run: |
           twine check dist/*
           python - <<'PY'
           import glob, zipfile
           whl = glob.glob("dist/*.whl")[0]
           names = zipfile.ZipFile(whl).namelist()
-          # Layout-agnostic: prompts ship under a top-level prompts/ dir in the
-          # current flat layout; match any prompts/*.md regardless of package root.
-          prompts = [n for n in names if "prompts/" in n and n.endswith(".md")]
-          assert len(prompts) >= 20, f"expected >=20 prompt files in wheel, got {len(prompts)}: {prompts}"
+          tops = {n.split("/")[0] for n in names}
+          # Must be the flat layout, NOT engine/-nested (which is import-broken).
+          assert "opendraft" in tops, f"opendraft package missing at top level: {sorted(tops)}"
+          assert "prompts" in tops, f"prompts package missing at top level: {sorted(tops)}"
+          assert "engine" not in tops, f"nested/broken layout detected (import opendraft would fail): {sorted(tops)}"
+          assert "opendraft/cli.py" in names, "opendraft/cli.py missing from wheel"
+          prompts = [n for n in names if n.startswith("prompts/") and n.endswith(".md")]
+          assert len(prompts) >= 20, f"expected >=20 top-level prompt files, got {len(prompts)}: {prompts}"
           assert any(n.endswith("scribe.md") for n in prompts), "scribe.md missing from wheel"
-          print(f"OK: {len(prompts)} prompt files bundled in {whl}")
+          print(f"OK: flat wheel {whl} with {len(prompts)} prompt files")
           PY
 
       - name: Publish to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes are documented in this file.
 
+## 1.7.4 - 2026-07-22
+
+### Added
+- LaTeX (`.tex`) output alongside the existing PDF, DOCX, and Markdown exports.
+  Every generated paper (and research exposé) now also produces a standalone,
+  compilable `<name>.tex` next to `<name>.pdf`/`<name>.docx`, bundled into the
+  ZIP. The `.tex` reuses the same Pandoc pipeline, preprocessing, and preamble as
+  the PDF path, so it carries the same style-formatted References/bibliography
+  (APA/IEEE/Chicago/MLA) as the PDF and compiles with XeLaTeX. It ships with a
+  `% !TeX program = xelatex` header. If Pandoc is not installed the `.tex` step
+  logs a warning and is skipped; the run still completes with its PDF/DOCX
+  (graceful degradation, never crashes the run).
+
+### Fixed
+- Title-page metadata (title, author, institution, department, advisor, ...) was
+  interpolated into the LaTeX preamble and Pandoc `--variable` values without
+  escaping, so a value containing `&`, `%`, `_`, `#`, `$`, `{`, or `}` produced a
+  document that Pandoc accepted but XeLaTeX rejected ("File ended while scanning
+  use of `\@argdef`"). Special characters are now escaped for both the PDF and the
+  new `.tex` output.
+
 ## 1.7.3 - 2026-07-20
 
 ### Fixed

--- a/engine/opendraft/version.py
+++ b/engine/opendraft/version.py
@@ -1,4 +1,4 @@
 """Version information for OpenDraft."""
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 __version_info__ = tuple(int(i) for i in __version__.split(".") if i.isdigit())

--- a/engine/phases/compile.py
+++ b/engine/phases/compile.py
@@ -17,6 +17,31 @@ from .context import DraftContext
 logger = logging.getLogger(__name__)
 
 
+def _export_latex_safe(md_path: Path, tex_path: Path, verbose: bool = False):
+    """
+    Best-effort LaTeX (.tex) export next to the PDF/DOCX outputs.
+
+    Never raises: a missing pandoc or a conversion error logs a warning and
+    returns None so the run always completes with its PDF/DOCX. Returns the
+    .tex Path on success (for ZIP bundling), else None.
+    """
+    try:
+        from utils.export_professional import export_latex
+        if verbose:
+            print("📐 Exporting LaTeX (.tex)...")
+        ok = export_latex(md_file=md_path, output_tex=tex_path)
+        if ok and tex_path.exists():
+            return tex_path
+        if verbose:
+            print("   ⚠️ LaTeX export skipped (pandoc unavailable or failed)")
+        logger.warning("LaTeX (.tex) export skipped or failed (non-critical)")
+    except Exception as tex_error:  # pragma: no cover - defensive
+        logger.warning(f"LaTeX (.tex) export raised (non-critical): {tex_error}")
+        if verbose:
+            print("   ⚠️ LaTeX export skipped (error)")
+    return None
+
+
 def run_expose_export(ctx: DraftContext) -> Tuple[Path, Path]:
     """
     Handle expose mode: generate research overview + outline only.
@@ -199,6 +224,10 @@ This research expose serves as a starting point for a comprehensive {ctx.academi
 
     if not docx_success or not docx_path.exists():
         raise RuntimeError(f"DOCX export failed for expose: {docx_path}")
+
+    # LaTeX (.tex) export — best-effort compilable source (non-critical for expose).
+    tex_path = ctx.folders['exports'] / f"{topic_slug}_expose.tex"
+    _export_latex_safe(expose_md_path, tex_path, verbose=ctx.verbose)
 
     if ctx.tracker:
         ctx.tracker.log_activity("🎉 Research Expose complete!", event_type="milestone", phase="completed")
@@ -476,6 +505,13 @@ generated_by: "OpenDraft AI - https://github.com/federicodeponte/opendraft"
     if ctx.tracker:
         ctx.tracker.log_activity("\u2705 Word document ready", event_type="found", phase="exporting")
 
+    # LaTeX (.tex) export \u2014 compilable source with the same formatted bibliography.
+    # Best-effort: never crashes the run if pandoc is unavailable.
+    tex_path = ctx.folders['exports'] / f"{base_filename}.tex"
+    tex_path = _export_latex_safe(final_md_path, tex_path, verbose=ctx.verbose)
+    if tex_path and ctx.tracker:
+        ctx.tracker.log_activity("\u2705 LaTeX source ready", event_type="found", phase="exporting")
+
     # ZIP bundle
     zip_path = ctx.folders['exports'] / f"{base_filename}.zip"
     try:
@@ -483,6 +519,8 @@ generated_by: "OpenDraft AI - https://github.com/federicodeponte/opendraft"
             zf.write(pdf_path, pdf_path.name)
             zf.write(docx_path, docx_path.name)
             zf.write(final_md_path, final_md_path.name)
+            if tex_path and tex_path.exists():
+                zf.write(tex_path, tex_path.name)
         if ctx.tracker:
             ctx.tracker.log_activity("📦 ZIP bundle created", event_type="found", phase="exporting")
     except Exception as zip_error:

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendraft"
-version = "1.7.3"
+version = "1.7.4"
 description = "Generate master-level research papers with real citations in minutes"
 readme = "README.md"
 license = {text = "MIT"}

--- a/engine/utils/export_professional.py
+++ b/engine/utils/export_professional.py
@@ -179,6 +179,78 @@ def export_pdf(
         return False
 
 
+def export_latex(
+    md_file: Path,
+    output_tex: Path,
+    options: Optional[PDFGenerationOptions] = None
+) -> bool:
+    """
+    Export markdown to a standalone, compilable LaTeX (.tex) source.
+
+    Reuses the same Pandoc pipeline, preprocessing, and preamble as the PDF path
+    (so the .tex carries the same style-formatted References/bibliography), but
+    emits editable LaTeX instead of a rendered PDF. Only Pandoc is required to
+    write the .tex (XeLaTeX is needed to later compile it to PDF).
+
+    Degrades gracefully: if Pandoc is not installed, logs a warning and returns
+    False instead of raising, so a run never crashes over a missing .tex.
+
+    Args:
+        md_file: Path to input markdown file
+        output_tex: Path for output .tex file
+        options: Generation options (uses academic defaults + YAML metadata if None)
+
+    Returns:
+        bool: True if the .tex was generated, False otherwise (non-fatal)
+    """
+    from utils.pdf_engines.pandoc_engine import PandocLatexEngine
+
+    md_file = Path(md_file)
+    output_tex = Path(output_tex)
+
+    engine = PandocLatexEngine()
+    if not engine.latex_is_available():
+        logger.warning(
+            "LaTeX (.tex) export skipped: pandoc not found on PATH. "
+            "Install pandoc to enable LaTeX output."
+        )
+        return False
+
+    metadata = extract_metadata_from_yaml(md_file)
+
+    if options is None:
+        options = PDFGenerationOptions(
+            title=metadata.get('title'),
+            subtitle=metadata.get('subtitle'),
+            author=metadata.get('author'),
+            date=metadata.get('date'),
+            institution=metadata.get('institution'),
+            department=metadata.get('department'),
+            course=metadata.get('degree'),
+            instructor=metadata.get('advisor'),
+            student_id=metadata.get('student_id'),
+            project_type=metadata.get('project_type'),
+            system_credit=metadata.get('system_credit')
+        )
+
+    logger.info("=" * 70)
+    logger.info(f"Generating LaTeX: {output_tex.name}")
+    logger.info(f"Input: {md_file}")
+    logger.info("=" * 70)
+
+    result = engine.generate_latex(md_file, output_tex, options)
+
+    if result.success:
+        logger.info(f"LaTeX created successfully: {result.output_path}")
+        if result.warnings:
+            for warning in result.warnings:
+                logger.warning(f"  - {warning}")
+        return True
+
+    logger.warning(f"LaTeX export failed: {result.error_message}")
+    return False
+
+
 def _normalize_yaml_for_pandoc(md_content: str) -> str:
     """
     Normalize YAML frontmatter field names to English for Pandoc compatibility.

--- a/engine/utils/pdf_engines/pandoc_engine.py
+++ b/engine/utils/pdf_engines/pandoc_engine.py
@@ -15,6 +15,35 @@ from typing import Optional, Dict, Any
 from .base import PDFEngine, PDFGenerationOptions, EngineResult
 
 
+# LaTeX special characters that must be escaped in plain-text values injected
+# directly into the preamble (title, author, institution, ...). Without this a
+# title like "Cost & Benefit_Analysis of 50%" makes the custom \maketitle
+# definition unparseable and XeLaTeX aborts with "File ended while scanning use
+# of \@argdef", even though Pandoc reported success. Applied to BOTH the PDF and
+# the .tex paths (they share _create_latex_preamble).
+def _latex_escape_text(value: Any) -> str:
+    """Escape LaTeX special characters in a plain-text metadata value."""
+    if value is None:
+        return ""
+    s = str(value)
+    # Backslash first, then the rest, so we don't double-escape our own escapes.
+    s = s.replace("\\", r"\textbackslash{}")
+    replacements = {
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\textasciicircum{}",
+    }
+    for char, escaped in replacements.items():
+        s = s.replace(char, escaped)
+    return s
+
+
 class PandocLatexEngine(PDFEngine):
     """
     Pandoc/LaTeX-based PDF generation engine.
@@ -198,6 +227,234 @@ class PandocLatexEngine(PDFEngine):
                 error_message=f"Unexpected error: {str(e)}"
             )
 
+    def latex_is_available(self) -> bool:
+        """
+        Check if standalone LaTeX (.tex) generation is possible.
+
+        Unlike PDF generation, emitting a .tex source only needs Pandoc; a LaTeX
+        compiler (XeLaTeX) is NOT required to WRITE the .tex file. The generated
+        document still targets XeLaTeX for compilation (fontspec preamble).
+        """
+        return shutil.which('pandoc') is not None
+
+    def generate_latex(
+        self,
+        md_file: Path,
+        output_tex: Path,
+        options: PDFGenerationOptions
+    ) -> EngineResult:
+        """
+        Generate a standalone, compilable LaTeX (.tex) source from Markdown.
+
+        Reuses the EXACT same preprocessing and preamble as the proven PDF path
+        (generate()), but emits a standalone LaTeX document instead of running
+        XeLaTeX to a PDF. The resulting .tex is a full document
+        (\\documentclass ... \\begin{document} ... \\end{document}) that compiles
+        with XeLaTeX (the preamble uses fontspec) and carries the same
+        style-formatted References section as the PDF, i.e. an embedded,
+        properly formatted bibliography.
+
+        Args:
+            md_file: Input markdown file
+            output_tex: Output .tex path
+            options: Generation options (shared with the PDF path)
+
+        Returns:
+            EngineResult with success/failure details
+        """
+        # Validate inputs (mirror of validate_inputs, but for a .tex target)
+        if not md_file.exists():
+            return EngineResult(
+                success=False,
+                engine_name=self.get_name(),
+                error_message=f"Input file not found: {md_file}"
+            )
+        if md_file.suffix.lower() not in ['.md', '.markdown']:
+            return EngineResult(
+                success=False,
+                engine_name=self.get_name(),
+                error_message=f"Input file must be markdown (.md), got: {md_file.suffix}"
+            )
+        if output_tex.suffix.lower() != '.tex':
+            return EngineResult(
+                success=False,
+                engine_name=self.get_name(),
+                error_message=f"Output file must have .tex extension, got: {output_tex.suffix}"
+            )
+        output_tex.parent.mkdir(parents=True, exist_ok=True)
+
+        temp_md = None
+        preamble_path = None
+        try:
+            with open(md_file, 'r', encoding='utf-8') as f:
+                md_content = f.read()
+
+            # Identical preprocessing chain to the PDF path (generate()).
+            original_md_content = md_content
+            md_content = self._normalize_yaml_for_pandoc(md_content)
+            md_content = self._unwrap_markdown_fence(md_content)
+            md_content = self._remove_title_heading(md_content, original_md_content)
+            md_content = self._strip_code_blocks(md_content)
+            md_content = self._normalize_bullet_lists(md_content)
+            md_content = self._escape_latex_special_chars(md_content)
+
+            import tempfile
+            import os
+            temp_fd, temp_path = tempfile.mkstemp(suffix='.md', text=True)
+            temp_md = Path(temp_path)
+            try:
+                with open(temp_md, 'w', encoding='utf-8') as f:
+                    f.write(md_content)
+            finally:
+                os.close(temp_fd)
+
+            # Same preamble the PDF uses (title page, TOC, fonts, hyperref, tables).
+            latex_preamble = self._create_latex_preamble(options, original_md_content)
+            preamble_path = (output_tex.parent / f"{output_tex.stem}_preamble.tex").resolve()
+            with open(preamble_path, 'w', encoding='utf-8') as f:
+                f.write(latex_preamble)
+
+            result = self._run_pandoc_latex(temp_md, output_tex, preamble_path, options)
+            return result
+
+        except Exception as e:
+            return EngineResult(
+                success=False,
+                engine_name=self.get_name(),
+                error_message=f"Unexpected error generating LaTeX: {str(e)}"
+            )
+        finally:
+            if preamble_path and preamble_path.exists():
+                try:
+                    preamble_path.unlink()
+                except Exception:
+                    pass
+            if temp_md and temp_md.exists():
+                try:
+                    temp_md.unlink()
+                except Exception:
+                    pass
+
+    def _run_pandoc_latex(
+        self,
+        md_file: Path,
+        output_tex: Path,
+        preamble_path: Path,
+        options: PDFGenerationOptions
+    ) -> EngineResult:
+        """
+        Run Pandoc to convert markdown to a standalone .tex source.
+
+        Mirrors _run_pandoc but targets `-t latex --standalone` (no --pdf-engine),
+        so the output is editable, compilable LaTeX rather than a PDF.
+        """
+        try:
+            margin = options.margins
+
+            cmd = [
+                'pandoc',
+                str(md_file.resolve()),
+                '-o', str(output_tex.resolve()),
+                '--standalone',
+                '--to', 'latex',
+                '--include-in-header', str(preamble_path.resolve()),
+                '--from', 'markdown+autolink_bare_uris+raw_tex',
+                '--variable', f'geometry:margin={margin}',
+                '--variable', f'fontsize={options.font_size}',
+                '--variable', 'papersize:letter',
+                '--variable', 'documentclass:article',
+            ]
+
+            # Pandoc --variable values are substituted literally (NOT LaTeX-escaped),
+            # and they land in \title{...}/\author{...}, so escape special chars here
+            # too or a title like "Cost & Benefit" breaks the compile.
+            if options.title:
+                cmd.extend(['--variable', f'title={_latex_escape_text(options.title)}'])
+            if options.author:
+                cmd.extend(['--variable', f'author={_latex_escape_text(options.author)}'])
+            if options.date:
+                cmd.extend(['--variable', f'date={_latex_escape_text(options.date)}'])
+            if options.institution:
+                cmd.extend(['--variable', f'institution={_latex_escape_text(options.institution)}'])
+            if options.department:
+                cmd.extend(['--variable', f'department={_latex_escape_text(options.department)}'])
+            if options.course:
+                cmd.extend(['--variable', f'course={_latex_escape_text(options.course)}'])
+            if options.instructor:
+                cmd.extend(['--variable', f'instructor={_latex_escape_text(options.instructor)}'])
+
+            if options.enable_toc:
+                cmd.append('--toc')
+                cmd.extend(['--variable', f'toc-depth={options.toc_depth}'])
+                cmd.extend(['--variable', 'toc-title=Table of Contents'])
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                cwd=output_tex.parent
+            )
+
+            if result.returncode != 0:
+                error_lines = result.stderr.split('\n')
+                latex_errors = [line for line in error_lines if line.startswith('!')]
+                if latex_errors:
+                    error_msg = '\n'.join(latex_errors[:3])
+                else:
+                    error_msg = result.stderr[-500:] if len(result.stderr) > 500 else result.stderr
+                return EngineResult(
+                    success=False,
+                    engine_name=self.get_name(),
+                    error_message=f"Pandoc LaTeX conversion failed:\n{error_msg}"
+                )
+
+            if not output_tex.exists():
+                return EngineResult(
+                    success=False,
+                    engine_name=self.get_name(),
+                    error_message="Pandoc did not generate .tex file"
+                )
+
+            # Prepend a TeX-editor magic comment so the .tex is compiled with the
+            # right engine. The preamble uses fontspec, so it requires XeLaTeX (or
+            # LuaLaTeX); pdflatex will fail. This makes the requirement explicit.
+            try:
+                original = output_tex.read_text(encoding='utf-8')
+                header = (
+                    "% !TeX program = xelatex\n"
+                    "% Generated by OpenDraft. Compile with XeLaTeX or LuaLaTeX "
+                    "(the preamble uses fontspec); pdflatex is not supported.\n"
+                )
+                if not original.lstrip().startswith('% !TeX'):
+                    output_tex.write_text(header + original, encoding='utf-8')
+            except OSError:
+                pass  # Non-fatal: the .tex is already valid without the comment.
+
+            warnings = []
+            if 'Warning' in result.stdout or 'Warning' in result.stderr:
+                warnings.append("Pandoc generated warnings (non-critical)")
+
+            return EngineResult(
+                success=True,
+                engine_name=self.get_name(),
+                output_path=output_tex,
+                warnings=warnings
+            )
+
+        except subprocess.TimeoutExpired:
+            return EngineResult(
+                success=False,
+                engine_name=self.get_name(),
+                error_message="Pandoc LaTeX conversion timed out (>2 minutes)"
+            )
+        except Exception as e:
+            return EngineResult(
+                success=False,
+                engine_name=self.get_name(),
+                error_message=f"Pandoc execution failed: {str(e)}"
+            )
+
     def _create_latex_preamble(self, options: PDFGenerationOptions, md_content: str = "") -> str:
         """
         Create LaTeX preamble for header customization.
@@ -306,16 +563,16 @@ class PandocLatexEngine(PDFEngine):
 '''
             # Add institution if provided
             if options.institution:
-                preamble += f'''    {{\\normalsize\\scshape {options.institution}\\par}}
+                preamble += f'''    {{\\normalsize\\scshape {_latex_escape_text(options.institution)}\\par}}
 '''
             # Add faculty if provided
             if hasattr(options, 'faculty') and options.faculty:
                 preamble += f'''    \\vspace{{0.08cm}}
-    {{\\small {options.faculty}\\par}}
+    {{\\small {_latex_escape_text(options.faculty)}\\par}}
 '''
             if options.department:
                 preamble += f'''    \\vspace{{0.08cm}}
-    {{\\small\\itshape {options.department}\\par}}
+    {{\\small\\itshape {_latex_escape_text(options.department)}\\par}}
 '''
 
             preamble += r'''
@@ -323,17 +580,17 @@ class PandocLatexEngine(PDFEngine):
     % Title Block - center
 '''
             if options.title:
-                preamble += f'''    {{\\Large\\bfseries {options.title}\\par}}
+                preamble += f'''    {{\\Large\\bfseries {_latex_escape_text(options.title)}\\par}}
 '''
             if options.subtitle:
                 preamble += f'''    \\vspace{{0.25cm}}
-    {{\\normalsize\\itshape {options.subtitle}\\par}}
+    {{\\normalsize\\itshape {_latex_escape_text(options.subtitle)}\\par}}
 '''
 
             # Add project type descriptor
             if options.project_type:
                 preamble += f'''    \\vspace{{0.5cm}}
-    {{\\small\\scshape {options.project_type}\\par}}
+    {{\\small\\scshape {_latex_escape_text(options.project_type)}\\par}}
 '''
 
             # Add degree
@@ -341,7 +598,7 @@ class PandocLatexEngine(PDFEngine):
                 preamble += f'''    \\vspace{{0.2cm}}
     {{\\small submitted in partial fulfillment of the requirements for the degree of\\par}}
     \\vspace{{0.1cm}}
-    {{\\normalsize\\bfseries {options.course}\\par}}
+    {{\\normalsize\\bfseries {_latex_escape_text(options.course)}\\par}}
 '''
 
             preamble += r'''
@@ -351,16 +608,16 @@ class PandocLatexEngine(PDFEngine):
     \vspace{0.15cm}
 '''
             if options.author:
-                preamble += f'''    {{\\normalsize\\bfseries {options.author}\\par}}
+                preamble += f'''    {{\\normalsize\\bfseries {_latex_escape_text(options.author)}\\par}}
 '''
             # Student ID or Matriculation number
             if options.student_id:
                 preamble += f'''    \\vspace{{0.08cm}}
-    {{\\small Matriculation No.: {options.student_id}\\par}}
+    {{\\small Matriculation No.: {_latex_escape_text(options.student_id)}\\par}}
 '''
             if hasattr(options, 'matriculation_number') and options.matriculation_number:
                 preamble += f'''    \\vspace{{0.08cm}}
-    {{\\small Matriculation No.: {options.matriculation_number}\\par}}
+    {{\\small Matriculation No.: {_latex_escape_text(options.matriculation_number)}\\par}}
 '''
 
             preamble += r'''
@@ -369,18 +626,18 @@ class PandocLatexEngine(PDFEngine):
 '''
             # Add advisor/supervisor
             if options.instructor:
-                preamble += f'''    {{\\small\\bfseries First Supervisor:}} {{\\small {options.instructor}\\par}}
+                preamble += f'''    {{\\small\\bfseries First Supervisor:}} {{\\small {_latex_escape_text(options.instructor)}\\par}}
 '''
             # Add second examiner if provided
             if hasattr(options, 'second_examiner') and options.second_examiner:
                 preamble += f'''    \\vspace{{0.08cm}}
-    {{\\small\\bfseries Second Examiner:}} {{\\small {options.second_examiner}\\par}}
+    {{\\small\\bfseries Second Examiner:}} {{\\small {_latex_escape_text(options.second_examiner)}\\par}}
 '''
 
             # Add system credit
             if options.system_credit:
                 preamble += f'''    \\vspace{{0.2cm}}
-    {{\\footnotesize\\itshape {options.system_credit}\\par}}
+    {{\\footnotesize\\itshape {_latex_escape_text(options.system_credit)}\\par}}
 '''
 
             preamble += r'''
@@ -389,7 +646,7 @@ class PandocLatexEngine(PDFEngine):
 '''
             # Add location if provided
             if hasattr(options, 'location') and options.location:
-                preamble += f'''    {{\\small {options.location}\\par}}
+                preamble += f'''    {{\\small {_latex_escape_text(options.location)}\\par}}
 '''
             # Add submission date, regular date, or default to today
             if hasattr(options, 'submission_date') and options.submission_date:
@@ -399,7 +656,7 @@ class PandocLatexEngine(PDFEngine):
             else:
                 display_date = datetime.now().strftime('%B %d, %Y')
             preamble += f'''    \\vspace{{0.08cm}}
-    {{\\small {display_date}\\par}}
+    {{\\small {_latex_escape_text(display_date)}\\par}}
 '''
 
             preamble += r'''
@@ -472,23 +729,26 @@ class PandocLatexEngine(PDFEngine):
                 '--variable', 'documentclass:article',
             ]
 
-            # Add title page metadata if provided
+            # Add title page metadata if provided.
+            # Pandoc --variable values are substituted literally (NOT LaTeX-escaped)
+            # into \title{...}/\author{...}, so escape special chars (&, %, _, #, ...)
+            # or a title like "Cost & Benefit" aborts the XeLaTeX compile.
             if options.title:
-                cmd.extend(['--variable', f'title={options.title}'])
+                cmd.extend(['--variable', f'title={_latex_escape_text(options.title)}'])
             if options.author:
-                cmd.extend(['--variable', f'author={options.author}'])
+                cmd.extend(['--variable', f'author={_latex_escape_text(options.author)}'])
             if options.date:
-                cmd.extend(['--variable', f'date={options.date}'])
+                cmd.extend(['--variable', f'date={_latex_escape_text(options.date)}'])
 
             # Add institutional metadata for professional cover page
             if options.institution:
-                cmd.extend(['--variable', f'institution={options.institution}'])
+                cmd.extend(['--variable', f'institution={_latex_escape_text(options.institution)}'])
             if options.department:
-                cmd.extend(['--variable', f'department={options.department}'])
+                cmd.extend(['--variable', f'department={_latex_escape_text(options.department)}'])
             if options.course:
-                cmd.extend(['--variable', f'course={options.course}'])
+                cmd.extend(['--variable', f'course={_latex_escape_text(options.course)}'])
             if options.instructor:
-                cmd.extend(['--variable', f'instructor={options.instructor}'])
+                cmd.extend(['--variable', f'instructor={_latex_escape_text(options.instructor)}'])
 
             # Add table of contents if enabled
             if options.enable_toc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opendraft"
-version = "1.7.3"
+version = "1.7.4"
 description = "Open-source AI research draft generator with 19 specialized agents and verified citations"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_latex_export.py
+++ b/tests/test_latex_export.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Tests for the LaTeX (.tex) export path (export_latex / generate_latex)
+ABOUTME: Verifies a standalone, structurally valid, special-char-safe .tex is produced
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add engine to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "engine"))
+
+from utils.export_professional import export_latex  # noqa: E402
+from utils.pdf_engines.pandoc_engine import _latex_escape_text  # noqa: E402
+
+
+PANDOC = shutil.which("pandoc") is not None
+XELATEX = shutil.which("xelatex") is not None
+
+pytestmark = pytest.mark.skipif(not PANDOC, reason="pandoc not installed")
+
+
+CLEAN_MD = """---
+title: "Transformer Architectures for Low-Resource Machine Translation"
+author: "OpenDraft AI"
+date: "July 2026"
+institution: "OpenDraft University"
+department: "Department of Computer Science"
+degree: "Master of Science"
+advisor: "Prof. Dr. A. Supervisor"
+project_type: "Master Draft"
+generated_by: "OpenDraft AI"
+---
+
+## Abstract
+This paper studies transformers (Vaswani et al., 2017).
+
+# 1. Introduction
+Neural machine translation has advanced rapidly.
+
+# 4. References
+
+Vaswani, A. (2017). Attention is all you need. *NeurIPS*.
+"""
+
+# Metadata packed with LaTeX special characters (the regression that broke 1.7.3
+# preamble/pandoc-variable interpolation).
+SPECIAL_MD = """---
+title: "Cost & Benefit_Analysis of 50% Tax #Reform"
+author: "Anne_Marie O'Brien & Co."
+date: "July 2026"
+institution: "Ludwig & Maximilian University"
+department: "Dept. of R&D"
+degree: "Master of Science"
+advisor: "Prof. Dr. Smith & Jones"
+project_type: "Master Draft"
+generated_by: "OpenDraft AI"
+---
+
+## Abstract
+Body with 100% coverage & R&D notes (Vaswani et al., 2017).
+
+# 1. Introduction
+Text.
+
+# 4. References
+
+Vaswani, A. (2017). Attention is all you need. *NeurIPS*.
+"""
+
+
+def _write(tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _assert_valid_standalone_tex(tex_path: Path):
+    assert tex_path.exists()
+    tex = tex_path.read_text(encoding="utf-8")
+    assert "\\documentclass" in tex
+    assert "\\begin{document}" in tex
+    assert "\\end{document}" in tex
+    # References/bibliography must be embedded
+    assert "References" in tex
+    # Environments balanced
+    begins = re.findall(r"\\begin\{([^}]+)\}", tex)
+    ends = re.findall(r"\\end\{([^}]+)\}", tex)
+    from collections import Counter
+    assert Counter(begins) == Counter(ends)
+    return tex
+
+
+def test_export_latex_produces_standalone_tex(tmp_path):
+    md = _write(tmp_path, "clean.md", CLEAN_MD)
+    tex = tmp_path / "clean.tex"
+    assert export_latex(md_file=md, output_tex=tex) is True
+    _assert_valid_standalone_tex(tex)
+
+
+def test_export_latex_escapes_special_chars(tmp_path):
+    md = _write(tmp_path, "special.md", SPECIAL_MD)
+    tex = tmp_path / "special.tex"
+    assert export_latex(md_file=md, output_tex=tex) is True
+    text = _assert_valid_standalone_tex(tex)
+    # The title's special chars must be escaped in the source.
+    assert "\\& Benefit\\_Analysis of 50\\% Tax \\#Reform" in text
+    # No raw, unescaped ampersand should remain inside the title-page metadata.
+    assert "Ludwig \\& Maximilian" in text
+
+
+def test_latex_escape_helper():
+    assert _latex_escape_text("A & B_C 50% #x") == "A \\& B\\_C 50\\% \\#x"
+    assert _latex_escape_text(None) == ""
+    assert _latex_escape_text("plain") == "plain"
+
+
+def test_export_latex_wrong_extension_rejected(tmp_path):
+    md = _write(tmp_path, "clean.md", CLEAN_MD)
+    # A .txt target must not be written by the LaTeX exporter.
+    out = tmp_path / "bad.txt"
+    assert export_latex(md_file=md, output_tex=out) is False
+    assert not out.exists()
+
+
+@pytest.mark.skipif(not XELATEX, reason="xelatex not installed")
+def test_special_char_tex_compiles(tmp_path):
+    md = _write(tmp_path, "special.md", SPECIAL_MD)
+    tex = tmp_path / "special.tex"
+    assert export_latex(md_file=md, output_tex=tex) is True
+    proc = subprocess.run(
+        ["xelatex", "-interaction=nonstopmode", "-halt-on-error", tex.name],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, proc.stdout[-2000:]
+    assert (tmp_path / "special.pdf").exists()


### PR DESCRIPTION
## What

Adds a real, compilable **LaTeX (`.tex`)** output alongside the existing PDF, DOCX, and Markdown exports, completing the advertised "PDF, Word, or LaTeX with a properly formatted bibliography". Bumps 1.7.3 -> 1.7.4.

## How

- New `PandocLatexEngine.generate_latex()` + `export_professional.export_latex()` reuse the **same Pandoc pipeline, preprocessing, and preamble** as the proven PDF path, but emit `pandoc -s -t latex` (no `--pdf-engine`) so the output is a standalone document (`\documentclass ... \begin{document} ... \end{document}`).
- The compiled body already carries inline style-formatted citations and a formatted **References** section (APA/IEEE/Chicago/MLA) produced by `CitationCompiler`; the `.tex` embeds that same section, so its bibliography is identical to the PDF's. It ships a `% !TeX program = xelatex` header and compiles with **XeLaTeX** (the preamble uses `fontspec`).
- Wired into both `run_compile_and_export` and `run_expose_export` (in `phases/compile.py`) as an extra output next to `<name>.pdf`/`.docx`, added to the ZIP bundle. The `(pdf_path, docx_path)` return contract is unchanged.

## Graceful degradation

If `pandoc` is not installed, the `.tex` step logs a warning and is skipped; the run still completes with its PDF/DOCX (never crashes).

## Bug fixed (caught by Codex review)

Title-page metadata (title, author, institution, department, advisor, ...) was interpolated into the LaTeX preamble **and** pandoc `--variable` values **without escaping**, so a value containing `& % _ # $ { }` produced a document pandoc accepted but XeLaTeX rejected (`File ended while scanning use of \@argdef`). This was a **latent bug in the PDF path too**. Special chars are now escaped for both PDF and `.tex`.

## Verification

- Real `.tex` generated and **compiled to PDF with XeLaTeX** (exit 0) for both clean and special-char metadata; `pdflatex` correctly rejects it (fontspec), matching the PDF path.
- Structural checks: valid preamble, matched `\begin`/`\end`, sections + embedded References present.
- **Flat wheel** builds from `engine/` and installs in a clean venv with all **25 prompts resolving** via `importlib.resources` (guards the 1.7.2 packaging regression).
- 5 new `tests/test_latex_export.py` + citation/packaging/output/cli suites green.

## Packaging

No packaging changes beyond the version bump. Flat layout (`opendraft`, `utils`, `phases`, `prompts`, ...) built from `engine/pyproject.toml` is intact; the change adds only Python code inside already-packaged modules.